### PR TITLE
refactor(gTile): centralize extension entry logic

### DIFF
--- a/gTile@shuairan/src/3_8/extension.ts
+++ b/gTile@shuairan/src/3_8/extension.ts
@@ -1,45 +1,17 @@
-/*****************************************************************
-
-             This extension has been developped by
-            vibou and forked to cinnamon by shuairan
-
-           With the help of the gnome-shell community
-
-******************************************************************/
-
-import { App } from "../base/app";
+import { createExtension } from "../base/extension";
 import { Platform } from "../base/types";
 import { get_tab_list, get_window_center, move_maximize_window, move_resize_window, reset_window, subscribe_to_focused_window_changes, unsubscribe_from_focused_window_changes } from "./utils";
 
-/*****************************************************************
-                         CONST & VARS
-*****************************************************************/
-let metadata: any;
-
-let app: App;
 const platform: Platform = {
-  move_maximize_window: move_maximize_window,
-  move_resize_window: move_resize_window,
-  reset_window: reset_window,
-  get_window_center: get_window_center,
-  subscribe_to_focused_window_changes: subscribe_to_focused_window_changes,
-  unsubscribe_from_focused_window_changes: unsubscribe_from_focused_window_changes,
-  get_tab_list: get_tab_list
-}
+  move_maximize_window,
+  move_resize_window,
+  reset_window,
+  get_window_center,
+  subscribe_to_focused_window_changes,
+  unsubscribe_from_focused_window_changes,
+  get_tab_list,
+};
 
-/*****************************************************************
-                            FUNCTIONS
-*****************************************************************/
-export const init = (meta: any) => {
-  metadata = meta;
-  imports.gi.Gtk.IconTheme.get_default().append_search_path(metadata.path + "/../icons");
-}
+const { init, enable, disable } = createExtension(platform);
 
-export const enable = () => {
-  app = new App(platform);
-}
-
-export const disable = () => {
-  // Key Bindings
-  app.destroy();
-}
+export { init, enable, disable };

--- a/gTile@shuairan/src/5_4/extension.ts
+++ b/gTile@shuairan/src/5_4/extension.ts
@@ -1,45 +1,17 @@
-/*****************************************************************
-
-             This extension has been developped by
-            vibou and forked to cinnamon by shuairan
-
-           With the help of the gnome-shell community
-
-******************************************************************/
-
-import { App } from "../base/app";
+import { createExtension } from "../base/extension";
 import { Platform } from "../base/types";
 import { get_tab_list, get_window_center, move_maximize_window, move_resize_window, reset_window, subscribe_to_focused_window_changes, unsubscribe_from_focused_window_changes } from "./utils";
 
-/*****************************************************************
-                         CONST & VARS
-*****************************************************************/
-let metadata: any;
-
-let app: App;
 const platform: Platform = {
-  move_maximize_window: move_maximize_window,
-  move_resize_window: move_resize_window,
-  reset_window: reset_window,
-  get_window_center: get_window_center,
-  subscribe_to_focused_window_changes: subscribe_to_focused_window_changes,
-  unsubscribe_from_focused_window_changes: unsubscribe_from_focused_window_changes,
-  get_tab_list: get_tab_list
-}
+  move_maximize_window,
+  move_resize_window,
+  reset_window,
+  get_window_center,
+  subscribe_to_focused_window_changes,
+  unsubscribe_from_focused_window_changes,
+  get_tab_list,
+};
 
-/*****************************************************************
-                            FUNCTIONS
-*****************************************************************/
-export const init = (meta: any) => {
-  metadata = meta;
-  imports.gi.Gtk.IconTheme.get_default().append_search_path(metadata.path + "/../icons");
-}
+const { init, enable, disable } = createExtension(platform);
 
-export const enable = () => {
-  app = new App(platform);
-}
-
-export const disable = () => {
-  // Key Bindings
-  app.destroy();
-}
+export { init, enable, disable };

--- a/gTile@shuairan/src/base/extension.ts
+++ b/gTile@shuairan/src/base/extension.ts
@@ -1,0 +1,22 @@
+import { App } from "./app";
+import { Platform } from "./types";
+
+export const createExtension = (platform: Platform) => {
+  let metadata: any;
+  let app: App;
+
+  const init = (meta: any) => {
+    metadata = meta;
+    imports.gi.Gtk.IconTheme.get_default().append_search_path(metadata.path + "/../icons");
+  };
+
+  const enable = () => {
+    app = new App(platform);
+  };
+
+  const disable = () => {
+    app.destroy();
+  };
+
+  return { init, enable, disable };
+};


### PR DESCRIPTION
## Summary
- Add shared `createExtension` entry in `src/base/extension.ts`
- Delegate version-specific entry files to shared module for Cinnamon 3.8 and 5.4

## Testing
- `npx webpack` *(fails: 403 Forbidden - GET https://registry.npmjs.org/webpack)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68913d832aac8323bffddd35f26897fa