### PR TITLE
Fix gTile build script path restoration

### DIFF
--- a/gTile@shuairan/build.sh
+++ b/gTile@shuairan/build.sh
@@ -18,4 +18,4 @@ cd $DIR
 npx webpack
 cd ..
 ./cinnamon-spices-makepot gTile@shuairan
-cd $PWD
+cd "$path"


### PR DESCRIPTION
## Summary
- restore original directory after build by using saved path variable
- add trailing newline to build.sh

## Testing
- `./cinnamon-spices-extensions/gTile@shuairan/build.sh` (fails: missing webpack and cinnamon-xlet-makepot; verified directory reset)


------
https://chatgpt.com/codex/tasks/task_e_68913d81b8ac83239cebb074c1adf72a