### PR TITLE
fix: disconnect all focused window handlers

### DIFF
--- a/gTile@shuairan/src/base/app.ts
+++ b/gTile@shuairan/src/base/app.ts
@@ -334,10 +334,10 @@ export class App implements IApp {
   /**
    * Disconnects from all subscribed events for the Previous Window
    */
-   private ResetFocusedWindow = () => {
+  private ResetFocusedWindow = () => {
     if (this.focusMetaWindowConnections.length > 0) {
-      for (var idx in this.focusMetaWindowConnections) {
-        this.focusMetaWindow?.disconnect(this.focusMetaWindowConnections[idx]);
+      for (const id of this.focusMetaWindowConnections) {
+        this.focusMetaWindow?.disconnect(id);
       }
     }
 


### PR DESCRIPTION
## Summary
- use `for...of` when iterating focus window connections
- ensure each connection id is disconnected before cleanup

## Testing
- `npx tsc -p gTile@shuairan/tsconfig.json` *(fails: Cannot find name 'imports')*
- `node - <<'NODE' ... NODE`


------
https://chatgpt.com/codex/tasks/task_e_68913d7feb4c83238d30d8ed5b656e62