### PR TITLE
Fix grid reset when row count decreases

### DIFF
--- a/gTile@shuairan/files/gTile@shuairan/extension.js
+++ b/gTile@shuairan/files/gTile@shuairan/extension.js
@@ -1005,6 +1005,8 @@ Grid.prototype = {
     this.table.destroy_all_children();
     this.cols = preferences.nbCols;
     this.rows = preferences.nbRows;
+    if (this.cols.length <= this.colKey || this.rows.length <= this.rowKey)
+      this.reset();
     this._displayElements();
   },
 

--- a/gTile@shuairan/src/base/ui/Grid.ts
+++ b/gTile@shuairan/src/base/ui/Grid.ts
@@ -286,7 +286,7 @@ export class Grid {
     this.cols = this.app.config.nbCols;
     this.rows = this.app.config.nbRows;
     // New grid is smaller than currently selected element, Reset selection
-    if (this.cols.length <= this.colKey || this.rows.length <= this.colKey)
+    if (this.cols.length <= this.colKey || this.rows.length <= this.rowKey)
       this.Reset();
 
     this.RebuildGridElements();


### PR DESCRIPTION
## Summary
- Ensure grid selection is cleared when new row count is smaller

## Testing
- `./build.sh` *(fails: 403 Forbidden and missing cinnamon-xlet-makepot)*
- `tsc -p tsconfig.json` *(fails: Cannot find name 'imports')*

------
https://chatgpt.com/codex/tasks/task_e_68913d1b438083238613e4b30a63c62a